### PR TITLE
Create a path object to represent where we are in the parsing

### DIFF
--- a/dict2any/jq_path.py
+++ b/dict2any/jq_path.py
@@ -1,0 +1,65 @@
+import re
+from dataclasses import dataclass
+from typing import Any
+
+ARRAY_REGEX = re.compile(r'\.?\[(\d)+\]')
+FIND_WITHIN_QUOTES = r'(?:[^".\n\[\]]*(?:\\")*?)*?'
+DICT_REGEX = re.compile(r'\.("{}"|{})(?=\.|$|\[)'.format(FIND_WITHIN_QUOTES, FIND_WITHIN_QUOTES))
+
+
+@dataclass(frozen=True)
+class JqPathPart:
+    name: str | None = None
+    index: int | None = None
+
+    def __str__(self):
+        return self.name if self.index is None else f'[{self.index}]'
+
+    def __post_init__(self):
+        if (self.name is None) == (self.index is None):
+            raise ValueError("Either name or index must be set")
+
+
+@dataclass(frozen=True)
+class JqPath:
+    parts: tuple[JqPathPart, ...]
+
+    def __post_init__(self):
+        if len(self.parts) == 0:
+            raise ValueError("Path must have at least one part")
+
+    @classmethod
+    def parse(cls, path: str) -> 'JqPath':
+        if path == "" or path == ".":
+            return cls(parts=(JqPathPart(name=""),))
+
+        jq_parts = [JqPathPart(name="")]
+        while len(path) > 0:
+            match = ARRAY_REGEX.match(path)
+            if match is not None:
+                jq_parts.append(JqPathPart(index=int(match.group(1))))
+                path = path[match.end() :]
+                continue
+
+            match = DICT_REGEX.match(path)
+            if match is not None:
+                name = match.group(1)
+                if len(name) == 0:
+                    raise ValueError(f"Invalid path: {path}")
+                jq_parts.append(JqPathPart(name=match.group(1)))
+                path = path[match.end() :]
+                continue
+
+            raise ValueError(f"Invalid path: {path}")
+        return cls(parts=tuple(jq_parts))
+
+    def path(self):
+        if len(self.parts) == 1:
+            return '.'
+        return ''.join([f'.{part}' for part in self.parts[1:]])
+
+    def parent(self) -> 'JqPath | None':
+        return JqPath(parts=self.parts[:-1]) if len(self.parts) > 1 else None
+
+    def child(self, *, name: str | None = None, index: int | None = None) -> 'JqPath':
+        return JqPath(parts=self.parts + (JqPathPart(name=name, index=index),))

--- a/tests/test_jq_path.py
+++ b/tests/test_jq_path.py
@@ -1,0 +1,92 @@
+from dict2any.jq_path import JqPath, JqPathPart
+import pytest
+
+
+def test_parse_empty():
+    assert JqPath.parse('') == JqPath(parts=(JqPathPart(name=''),))
+
+
+def test_parse_dot():
+    assert JqPath.parse('.') == JqPath(parts=(JqPathPart(name=''),))
+
+
+@pytest.mark.parametrize(
+    'path',
+    [
+        "..",
+        "[42.2]",
+        '"no_end_quote',
+        'no_start_quote"',
+        '[no_end_bracket',
+        'no_start_bracket]',
+        '["42"]',
+        '["not_a_number"]',
+        'a.b.[oops.d',
+    ],
+)
+def test_invalid_paths(path: str):
+    with pytest.raises(ValueError):
+        JqPath.parse(path)
+
+
+@pytest.mark.parametrize(
+    'path',
+    ['.', '.a', '.a.b', '.a.b.c', '.[1]', '.[1].[0]', '.[1].a' '.[0].a.[1]', '.[0]'],
+)
+def test_path(path: str):
+    jq_path = JqPath.parse(path)
+    assert jq_path.path() == path
+
+
+def test_normalized_array_path():
+    assert JqPath.parse('[0]').path() == '.[0]'
+    assert JqPath.parse('[0][1]').path() == '.[0].[1]'
+    assert JqPath.parse('[0].[1][2]').path() == '.[0].[1].[2]'
+    assert JqPath.parse('.a[0]').path() == '.a.[0]'
+
+
+@pytest.mark.parametrize(
+    ['path', 'expected'],
+    [
+        ('.', None),
+        ('', None),
+        ('.a', JqPath.parse('.')),
+        ('.a.b', JqPath.parse('.a')),
+        ('.a.b.c', JqPath.parse('.a.b')),
+        ('.a.b.c.[1]', JqPath.parse('.a.b.c')),
+        ('.a.b.c[1]', JqPath.parse('.a.b.c')),
+        ('[1]', JqPath.parse('.')),
+        ('.[2]', JqPath.parse('.')),
+        ('.[0][1]', JqPath.parse('.[0]')),
+    ],
+)
+def test_parent(path, expected):
+    assert JqPath.parse(path).parent() == expected
+
+
+def test_child_from_root():
+    assert JqPath.parse('.').child(name='a') == JqPath.parse('.a')
+
+
+def test_child_index_from_root():
+    assert JqPath.parse('.').child(index=1) == JqPath.parse('.[1]')
+
+
+def test_child():
+    assert JqPath.parse('.a').child(name='b') == JqPath.parse('.a.b')
+
+
+def test_child_index():
+    assert JqPath.parse('.a').child(index=1) == JqPath.parse('.a[1]')
+
+
+def test_part_validity():
+    with pytest.raises(ValueError, match="Either name or index must be set"):
+        JqPathPart()
+    with pytest.raises(ValueError, match="Either name or index must be set"):
+        JqPathPart(name="a", index=1)
+
+
+def test_verify_direct_initialization():
+    with pytest.raises(ValueError, match="Path must have at least one part"):
+        JqPath(parts=())

--- a/tests/test_jq_path.py
+++ b/tests/test_jq_path.py
@@ -1,5 +1,6 @@
-from dict2any.jq_path import JqPath, JqPathPart
 import pytest
+
+from dict2any.jq_path import JqPath, JqPathPart
 
 
 def test_parse_empty():


### PR DESCRIPTION
This implements a subset of the jq filter syntax: https://jqlang.github.io/jq/manual/#basic-filters

Essentially, you start at `.`, and then to go down dict keys you do `.my_key.my_inner_key` etc. and to index into an array it would be: `.my_list[5]` to get the 5th index, etc.