### PR TITLE
Create a list parser

### DIFF
--- a/dict2any/parsers/__init__.py
+++ b/dict2any/parsers/__init__.py
@@ -1,9 +1,2 @@
-from dict2any.parsers.base_types import (
-    BaseDictParser,
-    BaseListParser,
-    BoolParser,
-    FloatParser,
-    IntParser,
-    StringParser,
-)
+from dict2any.parsers.base_types import BoolParser, FloatParser, IntParser, StringParser
 from dict2any.parsers.parser import Parser, Stage, Subparse

--- a/dict2any/parsers/list.py
+++ b/dict2any/parsers/list.py
@@ -1,0 +1,37 @@
+from collections.abc import MutableSequence, Sequence
+from inspect import isclass
+from typing import Any, get_args, get_origin
+
+from dict2any.jq_path import JqPath
+from dict2any.parsers.parser import Parser, Stage, Subparse
+
+
+class ListParser(Parser):
+    def can_parse(self, stage: Stage, path: JqPath, field_type: type):
+        match stage:
+            case Stage.Exact:
+                return field_type is list or get_origin(field_type) is list
+            case Stage.Fallback:
+                if isclass(field_type) and issubclass(field_type, MutableSequence):
+                    return True
+                origin = get_origin(field_type)
+                # Make sure to only try parsing mutable sequences, not tuples
+                return isclass(origin) and issubclass(origin, list)
+            case _:
+                return False
+
+    def parse(self, stage: Stage, path: JqPath, field_type: type, data: Any, subparse: Subparse) -> Any:
+        match stage:
+            case Stage.Exact:
+                if not type(data) in (list, tuple):
+                    raise ValueError(f"Invalid type: {type(data)}")
+            case Stage.Fallback:
+                if not isinstance(data, Sequence):
+                    raise ValueError(f"Invalid type: {type(data)}")
+
+        args = get_args(field_type)
+        sub_type = Any if len(args) == 0 else args[0]
+        sub_items = [
+            subparse(path=path.child(index=index), field_type=sub_type, data=item) for index, item in enumerate(data)
+        ]
+        return field_type(sub_items)

--- a/dict2any/parsers/parser.py
+++ b/dict2any/parsers/parser.py
@@ -11,7 +11,7 @@ class Stage(StrEnum):
 
 
 class Subparse(Protocol):
-    def __call__(self, stage: Stage, path: JqPath, field_type: type, data: Any) -> Any:
+    def __call__(self, *, path: JqPath, field_type: type, data: Any) -> Any:
         ...
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import pytest
 
 from dict2any.jq_path import JqPath
@@ -6,3 +8,8 @@ from dict2any.jq_path import JqPath
 @pytest.fixture
 def path():
     return JqPath.parse('.')
+
+
+@pytest.fixture
+def subparser() -> Mock:
+    return Mock(side_effect=lambda *args, **kwargs: kwargs['data'])

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,0 +1,152 @@
+from collections.abc import MutableSequence
+from dataclasses import dataclass, fields
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from dict2any.jq_path import JqPath
+from dict2any.parsers import Stage
+from dict2any.parsers.list import ListParser
+
+
+class SubList(list):
+    pass
+
+
+class MyCustomSequence(MutableSequence):
+    def __init__(self, items):
+        self.items = items
+
+    def __eq__(self, other):
+        return isinstance(other, MyCustomSequence) and self.items == other.items
+
+    def __getitem__(self, index):
+        return self.items.__getitem__(index)
+
+    def __setitem__(self, index, val):
+        return self.items.__setitem__(index)
+
+    def __delitem__(self, index):
+        return self.items.__delitem__(index)
+
+    def __len__(self):
+        return self.items.__len__()
+
+    def insert(self, index, val):
+        return self.items.insert(index, val)
+
+
+@dataclass
+class MyData:
+    my_list: list
+    my_int_list: list[int]
+    my_str_list: list[str]
+    my_list_list: list[list[str]]
+    my_tuple: tuple
+    my_int_tuple: tuple[int]
+    my_list_tuple: tuple[list]
+
+
+my_data_types = {field.name: field.type for field in fields(MyData)}
+
+
+@pytest.fixture
+def subparser() -> Mock:
+    return Mock(side_effect=lambda *args, **kwargs: kwargs['data'])
+
+
+@pytest.mark.parametrize(
+    ['field_type', 'expected'],
+    [
+        (list, True),
+        (tuple, False),
+        (SubList, False),
+        (MyCustomSequence, False),
+        (my_data_types['my_int_list'], True),
+        (my_data_types['my_str_list'], True),
+        (my_data_types['my_list_list'], True),
+        (my_data_types['my_tuple'], False),
+        (my_data_types['my_int_tuple'], False),
+        (my_data_types['my_list_tuple'], False),
+    ],
+)
+def test_can_parse_exact(field_type: type, expected: bool, path: JqPath):
+    assert ListParser().can_parse(Stage.Exact, path, field_type) == expected
+
+
+@pytest.mark.parametrize(
+    ['field_type', 'expected'],
+    [
+        (MyCustomSequence, True),
+        (SubList, True),
+        (list, True),
+        (tuple, False),
+        (my_data_types['my_int_list'], True),
+        (my_data_types['my_str_list'], True),
+        (my_data_types['my_list_list'], True),
+        (my_data_types['my_tuple'], False),
+        (my_data_types['my_int_tuple'], False),
+        (my_data_types['my_list_tuple'], False),
+    ],
+)
+def test_can_parse_fallback(field_type: type, expected: bool, path: JqPath):
+    assert ListParser().can_parse(Stage.Fallback, path, field_type) == expected
+
+
+def test_can_parse_override(path: JqPath):
+    assert ListParser().can_parse(Stage.Override, path, list) == False
+
+
+@pytest.mark.parametrize(
+    ['field_type', 'data', 'expected'],
+    [
+        (list, [], []),
+        (list, [1], [1]),
+        (list, [1, 2], [1, 2]),
+        (my_data_types['my_int_list'], [1, 2], [1, 2]),
+        (my_data_types['my_str_list'], ["a"], ["a"]),
+        (list, (1, 2), [1, 2]),
+        (list, [[1], [2, 3]], [[1], [2, 3]]),
+    ],
+)
+def test_parse_exact(field_type: type, data: Any, expected: Any, path: JqPath, subparser: Mock):
+    assert ListParser().parse(Stage.Exact, path, field_type, data, subparser) == expected
+    assert subparser.call_count == len(data)
+    for i, _ in enumerate(data):
+        assert subparser.call_args_list[i].kwargs["path"].path() == f"{path.path()}[{i}]"
+        expected_field_type = Any if field_type is list else type(data[0])
+        assert subparser.call_args_list[i].kwargs["field_type"] == expected_field_type
+        assert subparser.call_args_list[i].kwargs["data"] == data[i]
+
+
+def test_parse_exact_fails_for_non_lists(path: JqPath, subparser: Mock):
+    with pytest.raises(ValueError):
+        ListParser().parse(Stage.Exact, path, list, SubList(), subparser)
+
+    with pytest.raises(ValueError):
+        ListParser().parse(Stage.Exact, path, list, {"hello": "world"}, subparser)
+
+
+@pytest.mark.parametrize(
+    ['field_type', 'data', 'expected'],
+    [
+        (SubList, [], SubList([])),
+        (SubList, [1], SubList([1])),
+        (SubList, (1, 2), SubList([1, 2])),
+        (MyCustomSequence, [1, 2], MyCustomSequence([1, 2])),
+    ],
+)
+def test_parse_fallback(field_type: type, data: Any, expected: Any, path: JqPath, subparser: Mock):
+    assert ListParser().parse(Stage.Fallback, path, field_type, data, subparser) == expected
+    assert subparser.call_count == len(data)
+    for i, _ in enumerate(data):
+        assert subparser.call_args_list[i].kwargs["path"].path() == f"{path.path()}[{i}]"
+        expected_field_type = Any if field_type in (list, SubList, MyCustomSequence) else type(data[0])
+        assert subparser.call_args_list[i].kwargs["field_type"] == expected_field_type
+        assert subparser.call_args_list[i].kwargs["data"] == data[i]
+
+
+def test_parse_fallbock_fails_for_non_lists(path: JqPath, subparser: Mock):
+    with pytest.raises(ValueError):
+        ListParser().parse(Stage.Fallback, path, list, {"hello": "world"}, subparser)

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -51,11 +51,6 @@ class MyData:
 my_data_types = {field.name: field.type for field in fields(MyData)}
 
 
-@pytest.fixture
-def subparser() -> Mock:
-    return Mock(side_effect=lambda *args, **kwargs: kwargs['data'])
-
-
 @pytest.mark.parametrize(
     ['field_type', 'expected'],
     [


### PR DESCRIPTION
Adds the ability to parse generic lists, eg `list`, as well as `list[T]`