### PR TITLE
Fix type checking when parsing

### DIFF
--- a/dict2any/parsers/base_types.py
+++ b/dict2any/parsers/base_types.py
@@ -21,15 +21,9 @@ class BaseParser(Parser):
                 return False
 
     def parse(self, stage: Stage, path: JqPath, field_type: type, data: Any, subparse: Subparse) -> Any:
-        match stage:
-            case Stage.Exact:
-                if type(data) is not self.field_type:
-                    raise ValueError(f"Invalid type: {type(data)}")
-                return data
-            case Stage.Fallback:
-                if not isinstance(data, self.field_type):
-                    raise ValueError(f"Invalid type: {type(data)}")
-                return field_type(data)
+        if not isinstance(data, self.field_type):
+            raise ValueError(f"Invalid type: {type(data)}")
+        return data
 
 
 def create_base_parser(field_type: type) -> type[Parser]:

--- a/dict2any/parsers/list.py
+++ b/dict2any/parsers/list.py
@@ -21,13 +21,8 @@ class ListParser(Parser):
                 return False
 
     def parse(self, stage: Stage, path: JqPath, field_type: type, data: Any, subparse: Subparse) -> Any:
-        match stage:
-            case Stage.Exact:
-                if not type(data) in (list, tuple):
-                    raise ValueError(f"Invalid type: {type(data)}")
-            case Stage.Fallback:
-                if not isinstance(data, Sequence):
-                    raise ValueError(f"Invalid type: {type(data)}")
+        if not isinstance(data, Sequence):
+            raise ValueError(f"Invalid type: {type(data)}")
 
         args = get_args(field_type)
         sub_type = Any if len(args) == 0 else args[0]

--- a/tests/test_base_types.py
+++ b/tests/test_base_types.py
@@ -61,6 +61,7 @@ def test_parse(path: JqPath, subparser: Mock):
     assert IntParser().parse(Stage.Exact, path, int, 42, subparser) == 42
     assert FloatParser().parse(Stage.Exact, path, float, 42.0, subparser) == 42.0
     assert StringParser().parse(Stage.Exact, path, str, "42", subparser) == "42"
+    assert StringParser().parse(Stage.Exact, path, MyStr, MyStr("42"), subparser) == MyStr("42")
     assert StringParser().parse(Stage.Fallback, path, MyStr, MyStr("42"), subparser) == MyStr("42")
 
 

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -110,6 +110,7 @@ def test_can_parse_override(path: JqPath):
         (list, [], []),
         (list, [1], [1]),
         (list, [1, 2], [1, 2]),
+        (list, MyCustomSequence([1, 2]), [1, 2]),
         (my_data_types['my_int_list'], [1, 2], [1, 2]),
         (my_data_types['my_str_list'], ["a"], ["a"]),
         (list, (1, 2), [1, 2]),
@@ -126,12 +127,12 @@ def test_parse_exact(field_type: type, data: Any, expected: Any, path: JqPath, s
         assert subparser.call_args_list[i].kwargs["data"] == data[i]
 
 
-def test_parse_exact_fails_for_non_lists(path: JqPath, subparser: Mock):
-    with pytest.raises(ValueError):
-        ListParser().parse(Stage.Exact, path, list, SubList(), subparser)
-
+def test_parse_fails_for_non_lists(path: JqPath, subparser: Mock):
     with pytest.raises(ValueError):
         ListParser().parse(Stage.Exact, path, list, {"hello": "world"}, subparser)
+
+    with pytest.raises(ValueError):
+        ListParser().parse(Stage.Fallback, path, list, {"hello": "world"}, subparser)
 
 
 @pytest.mark.parametrize(
@@ -153,8 +154,3 @@ def test_parse_fallback(field_type: type, data: Any, expected: Any, path: JqPath
         expected_field_type = Any if field_type in (list, SubList, MyCustomSequence) else type(data[0])
         assert subparser.call_args_list[i].kwargs["field_type"] == expected_field_type
         assert subparser.call_args_list[i].kwargs["data"] == data[i]
-
-
-def test_parse_fallbock_fails_for_non_lists(path: JqPath, subparser: Mock):
-    with pytest.raises(ValueError):
-        ListParser().parse(Stage.Fallback, path, list, {"hello": "world"}, subparser)


### PR DESCRIPTION
The strict type checking for exact only implies whether the parser should run at all. For actually handling the data class, it should cover any compatible data type